### PR TITLE
Fix($min, $max): Correct behavior for non-existent fields

### DIFF
--- a/neosqlite/collection.py
+++ b/neosqlite/collection.py
@@ -422,11 +422,11 @@ class Collection:
                             doc_to_update[k] *= v
                 case "$min":
                     for k, v in value.items():
-                        if k in doc_to_update and doc_to_update[k] > v:
+                        if k not in doc_to_update or doc_to_update[k] > v:
                             doc_to_update[k] = v
                 case "$max":
                     for k, v in value.items():
-                        if k in doc_to_update and doc_to_update[k] < v:
+                        if k not in doc_to_update or doc_to_update[k] < v:
                             doc_to_update[k] = v
                 case _:
                     raise MalformedQueryException(

--- a/tests/test_update_operations.py
+++ b/tests/test_update_operations.py
@@ -137,3 +137,23 @@ def test_update_many_combined():
     assert alice["score"] == 85  # max(80, 85)
     assert result.matched_count == 1
     assert result.modified_count == 1
+
+
+def test_upsert_min_max_non_existent_field():
+    """Test $min and $max operators on non-existent fields during an upsert."""
+    db = neosqlite.Connection(":memory:")
+    collection = db["test"]
+
+    # Upsert with $min on a non-existent document
+    collection.update_one({"name": "Frank"}, {"$min": {"score": 50}}, upsert=True)
+    frank = collection.find_one({"name": "Frank"})
+    assert frank is not None
+    assert "score" in frank
+    assert frank["score"] == 50
+
+    # Upsert with $max on a non-existent document
+    collection.update_one({"name": "Grace"}, {"$max": {"score": 60}}, upsert=True)
+    grace = collection.find_one({"name": "Grace"})
+    assert grace is not None
+    assert "score" in grace
+    assert grace["score"] == 60


### PR DESCRIPTION
The Python fallback implementation of the `$min` and `$max` update operators did not correctly handle cases where the specified field does not exist in the document. Instead of setting the field to the given value, it did nothing.

This commit corrects the logic in the `_perform_python_update` method to align with MongoDB's behavior, ensuring that `$min` and `$max` set the field if it is not present in the document.

A new test case is added to verify this behavior and prevent future regressions.